### PR TITLE
skipchannels are initially empty and are emptied through `recv`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub struct Receiver<T> {
 impl<T> Receiver<T> {
     /// Returns the last sent value. Returns `None` if
     /// no value was sent since the last call to `recv`.
-    pub fn recv(&mut self) -> Option<T> {
+    pub fn recv(&self) -> Option<T> {
         let mut result = None;
         for t in self.receiver.try_iter() {
             result = Some(t);
@@ -75,14 +75,14 @@ mod tests {
 
         #[test]
         fn allows_to_send_one_value() {
-            let (sender, mut receiver) = skipchannel();
+            let (sender, receiver) = skipchannel();
             sender.send("foo");
             assert_eq!(receiver.recv(), Some("foo"));
         }
 
         #[test]
         fn allows_to_send_values_between_threads() {
-            let (sender, mut receiver) = skipchannel();
+            let (sender, receiver) = skipchannel();
             sender.send("foo");
             let read_result = parallel(move || receiver.recv());
             assert_eq!(read_result, Some("foo"));
@@ -90,13 +90,13 @@ mod tests {
 
         #[test]
         fn yields_none_when_nothing_is_sent() {
-            let (_sender, mut receiver): (Sender<i32>, Receiver<i32>) = skipchannel();
+            let (_sender, receiver): (Sender<i32>, Receiver<i32>) = skipchannel();
             assert_eq!(receiver.recv(), None);
         }
 
         #[test]
         fn skips_all_values_but_the_last() {
-            let (sender, mut receiver) = skipchannel();
+            let (sender, receiver) = skipchannel();
             sender.send("foo");
             sender.send("bar");
             let read_result = parallel(move || receiver.recv());
@@ -105,7 +105,7 @@ mod tests {
 
         #[test]
         fn returns_none_when_a_sent_value_is_already_consumed() {
-            let (sender, mut receiver) = skipchannel();
+            let (sender, receiver) = skipchannel();
             sender.send("foo");
             receiver.recv();
             assert_eq!(receiver.recv(), None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,13 @@
 //!
 //! use skipchannel::skipchannel;
 //!
-//! let (writer, mut reader) = skipchannel(0);
+//! let (writer, mut reader) = skipchannel();
 //! let thread = std::thread::spawn(move || {
 //!   std::thread::sleep(std::time::Duration::new(0, 100_000_000));
-//!   reader.last()
+//!   reader.recv()
 //! });
 //! writer.write(1);
-//! assert_eq!(thread.join().unwrap(), 1);
+//! assert_eq!(thread.join().unwrap(), Some(1));
 //! ```
 use std::sync::mpsc::{channel, Receiver, Sender};
 
@@ -33,29 +33,25 @@ impl<T> Writer<T> {
 
 pub struct Reader<T> {
     receiver: Receiver<T>,
-    last: T,
 }
 
-impl<T: Clone> Reader<T> {
-    pub fn last(&mut self) -> T {
+impl<T> Reader<T> {
+    /// Returns the last sent value. Returns `None` if
+    /// no value was sent since the last call to `recv`.
+    pub fn recv(&mut self) -> Option<T> {
+        let mut result = None;
         for t in self.receiver.try_iter() {
-            self.last = t.clone();
+            result = Some(t);
         }
-        self.last.clone()
+        result
     }
 }
 
 /// Creates a [Writer](struct.Writer.html) and [Reader](struct.Reader.html)
 /// for your skipchannel.
-pub fn skipchannel<T>(initial: T) -> (Writer<T>, Reader<T>) {
+pub fn skipchannel<T>() -> (Writer<T>, Reader<T>) {
     let (sender, receiver) = channel();
-    (
-        Writer { sender },
-        Reader {
-            receiver,
-            last: initial,
-        },
-    )
+    (Writer { sender }, Reader { receiver })
 }
 
 #[cfg(test)]
@@ -78,26 +74,41 @@ mod tests {
         }
 
         #[test]
-        fn allows_to_send_values_between_threads() {
-            let (writer, mut reader) = skipchannel("");
+        fn allows_to_send_one_value() {
+            let (writer, mut reader) = skipchannel();
             writer.write("foo");
-            let read_result = parallel(move || reader.last());
-            assert_eq!(read_result, "foo");
+            assert_eq!(reader.recv(), Some("foo"));
         }
 
         #[test]
-        fn yields_initial_value_when_nothing_is_sent() {
-            let (_writer, mut reader): (Writer<i32>, Reader<i32>) = skipchannel(0);
-            assert_eq!(reader.last(), 0);
+        fn allows_to_send_values_between_threads() {
+            let (writer, mut reader) = skipchannel();
+            writer.write("foo");
+            let read_result = parallel(move || reader.recv());
+            assert_eq!(read_result, Some("foo"));
+        }
+
+        #[test]
+        fn yields_none_when_nothing_is_sent() {
+            let (_writer, mut reader): (Writer<i32>, Reader<i32>) = skipchannel();
+            assert_eq!(reader.recv(), None);
         }
 
         #[test]
         fn skips_all_values_but_the_last() {
-            let (writer, mut reader) = skipchannel("");
+            let (writer, mut reader) = skipchannel();
             writer.write("foo");
             writer.write("bar");
-            let read_result = parallel(move || reader.last());
-            assert_eq!(read_result, "bar");
+            let read_result = parallel(move || reader.recv());
+            assert_eq!(read_result, Some("bar"));
+        }
+
+        #[test]
+        fn returns_none_when_a_sent_value_is_already_consumed() {
+            let (writer, mut reader) = skipchannel();
+            writer.write("foo");
+            reader.recv();
+            assert_eq!(reader.recv(), None);
         }
     }
 }


### PR DESCRIPTION
This PR changes the behavior to be more like normal channels. Skipchannels can now be empty when the value is read. Before, reading from the skipchannel would always return the last sent value, regardless of whether it was already read.

If we want the old behavior back, I think it should be implemented in terms of this skipchannel (maybe in a separate module).