### PR TITLE
remove newer rustc warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ mod tests {
 
     mod skip_channel {
         use super::*;
+        use std::panic::panic_any;
 
         fn parallel<F, T>(f: F) -> T
         where
@@ -107,7 +108,7 @@ mod tests {
             let f_handle = std::thread::spawn(f);
             match f_handle.join() {
                 Ok(t) => t,
-                Err(err) => panic!(err),
+                Err(err) => panic_any(err),
             }
         }
 


### PR DESCRIPTION
Before this change this warning was triggered:
https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#non-fmt-panic